### PR TITLE
Added & to presave and & to uninstall functions to resolve php8 errors

### DIFF
--- a/class.CloserPlugin.php
+++ b/class.CloserPlugin.php
@@ -501,7 +501,7 @@ PIECE;
      *
      * @see Plugin::uninstall()
      */
-    function uninstall() {
+    function uninstall(&$errors) {
         $errors = array();
         global $ost;
         // Send an alert to the system admin:

--- a/config.php
+++ b/config.php
@@ -31,7 +31,7 @@ class CloserPluginConfig extends PluginConfig {
         return Plugin::translate('closer');
     }
 
-    function pre_save($config, &$errors) {
+    function pre_save(&$config, &$errors) {
         list ($__, $_N) = self::translate();
 
         // Validate the free-text fields of numerical configurations are in fact numerical..


### PR DESCRIPTION
This allows uses with php 8.0 and OsTicket v1.16.

This isn't tested with v1.17 yet but it does load at least.

There are some known issues with the current RC3 of OsTicket v1.17 and these plugins so worth checking if settings are being read and used correctly.