### PR TITLE
multi-instance for osTicket 1.17+

### DIFF
--- a/class.CloserPlugin.php
+++ b/class.CloserPlugin.php
@@ -10,7 +10,7 @@
  * @see https://github.com/Cartmega/plugin-autocloser 
  */
 foreach ([
-'canned',
+ 'canned',
  'format',
  'list',
  'orm',
@@ -142,7 +142,7 @@ class CloserPlugin extends Plugin {
                         // Fetch ticket as an Object
                         $ticket = Ticket::lookup($ticket_id);
                         if (!$ticket instanceof Ticket) {
-	                        $ost->logWarning("CloserPlugin", "Ticket $ticket_id was not instatiable. :-(", false);
+	                        $this->LOG[]="Ticket $ticket_id was not instatiable. :-(";
                             continue;
                         }
 

--- a/class.CloserPlugin.php
+++ b/class.CloserPlugin.php
@@ -1,13 +1,16 @@
 <?php
-
 /**
- * @file class.CloserPlugin.php :: Requires PHP5.6+
+ * @file class.CloserPlugin.php :: 
+ * @  requires osTicket 1.17+ & PHP8.0+
+ * @  multi-instance: yes
  *
  * @author Grizly <clonemeagain@gmail.com>
  * @see https://github.com/clonemeagain/plugin-autocloser
+ * @fork by Cartmega <www.cartmega.com>
+ * @see https://github.com/Cartmega/plugin-autocloser 
  */
 foreach ([
- 'canned',
+'canned',
  'format',
  'list',
  'orm',
@@ -34,7 +37,7 @@ class CloserPlugin extends Plugin {
      *
      * @var boolean
      */
-    const DEBUG = FALSE;
+    const DEBUG = TRUE;
 
     /**
      * The name that appears in threads as: Closer Plugin.
@@ -52,20 +55,27 @@ class CloserPlugin extends Plugin {
      * @see Plugin::bootstrap()
      */
     public function bootstrap() {
+	// ---------------------------------------------------------------------
+	// Fetch the config
+	// ---------------------------------------------------------------------
+	// Save config and instance for use later in the signal, when it is called
+	$config = $this->config;
+	$instance = $this->config->instance;
+
         // Listen for cron Signal, which only happens at end of class.cron.php:
-        Signal::connect('cron', function ($ignored, $data) {
+        Signal::connect('cron', function ($ignored, $data) use (&$config, $instance) {
 
             // Autocron is an admin option, we can filter out Autocron Signals
             // to ensure changing state for potentially hundreds/thousands
             // of tickets doesn't affect interactive Agent/User experience.
-            $use_autocron = $this->getConfig()->get('use_autocron');
+            $use_autocron = $config->get('use_autocron');
 
             // Autocron Cron Signals are sent with this array key set to TRUE
             $is_autocron = (isset($data['autocron']) && $data['autocron']);
 
             // Normal cron isn't Autocron:
             if (!$is_autocron || ($use_autocron && $is_autocron))
-                $this->logans_run_mode();
+                $this->logans_run_mode($config);
         });
     }
 
@@ -74,40 +84,33 @@ class CloserPlugin extends Plugin {
      * whatever. = Welcome to the 23rd Century. The perfect world of total
      * pleasure. ... there's just one catch.
      */
-    private function logans_run_mode() {
-        $config = $this->getConfig();
+    private function logans_run_mode(&$config) {
+	global $ost;
         if ($this->is_time_to_run($config)) {
-            // Use the number of config groups to run the closer as many times as is needed.
-            foreach (range(1, CloserPluginConfig::NUMBER_OF_SETTINGS) as $group_id) {
-                if (!$config->get('group-enabled-' . $group_id)) {
-                    continue;
-                }
-
+	
                 try {
-                    $open_ticket_ids = $this->find_ticket_ids($config, $group_id);
+                    $open_ticket_ids = $this->find_ticket_ids($config);
                     if (self::DEBUG) {
-                        error_log(
-                                "CloserPlugin group [$group_id] $group_name has " .
-                                count($open_ticket_ids) . " open tickets.");
+                        $ost->logWarning("CloserPlugin", count($open_ticket_ids) . " open tickets.", false);
                     }
 
                     // Bail if there is no work to do
                     if (!count($open_ticket_ids)) {
-                        continue;
+                        return true;
                     }
 
-                    // Find the new TicketStatus from the Setting Group config:
+                    // Find the new TicketStatus from the Setting config:
                     $new_status = TicketStatus::lookup(
                                     array(
-                                        'id' => (int) $config->get('to-status-' . $group_id)
+                                        'id' => (int) $config->get('to-status')
                     ));
 
                     // Admin note is just text
-                    $admin_note = $config->get('admin-note-' . $group_id) ?: FALSE;
+                    $admin_note = $config->get('admin-note') ?: FALSE;
 
                     // Fetch the actual content of the reply, "html" means load with images, 
                     // I don't think it works with attachments though.
-                    $admin_reply = $config->get('admin-reply-' . $group_id);
+                    $admin_reply = $config->get('admin-reply');
                     if (is_numeric($admin_reply) && $admin_reply) {
                         // We have a valid Canned_Response ID, fetch the actual Canned:
                         $admin_reply = Canned::lookup($admin_reply);
@@ -122,8 +125,8 @@ class CloserPlugin extends Plugin {
                                 "Found the following details:\nAdmin Note: $admin_note\n\nAdmin Reply: $admin_reply\n";
                     }
 
-                    // Get the robot for this group
-                    $robot = $this->getConfig()->get('robot-account-' . $group_id);
+                    // Get the robot for this config
+                    $robot = $config->get('robot-account');
                     $robot = ($robot>0)? $robot = Staff::lookup($robot) : null;
 
                     // Go through each ticket ID:
@@ -132,7 +135,7 @@ class CloserPlugin extends Plugin {
                         // Fetch ticket as an Object
                         $ticket = Ticket::lookup($ticket_id);
                         if (!$ticket instanceof Ticket) {
-                            error_log("Ticket $ticket_id was not instatiable. :-(");
+	                        $ost->logWarning("CloserPlugin", "Ticket $ticket_id was not instatiable. :-(", false);
                             continue;
                         }
 
@@ -163,13 +166,11 @@ class CloserPlugin extends Plugin {
                     }
                 } catch (Exception $e) {
                     // Well, something borked
-                    error_log(
-                            "Exception encountered, we'll soldier on, but something is broken!");
-                    error_log($e->getMessage());
+                    $ost->logWarning("CloserPlugin", "Exception encountered, we'll soldier on, but something is broken!", false);
+                    $ost->logWarning("CloserPlugin", $e->getMessage(), false);
                     if (self::DEBUG)
                         print_r($e->getTrace());
                 }
-            }
         }
     }
 
@@ -181,7 +182,7 @@ class CloserPlugin extends Plugin {
      * @param PluginConfig $config
      * @return boolean
      */
-    private function is_time_to_run(PluginConfig $config) {
+    private function is_time_to_run(PluginConfig &$config) {
         // We can store arbitrary things in the config, like, when we ran this last:
         $last_run = $config->get('last-run');
         $now = Misc::dbtime(); // Never assume about time.. 
@@ -191,7 +192,8 @@ class CloserPlugin extends Plugin {
         $next_run = 0;
 
         // Convert purge frequency to a comparable format to timestamps:
-        if ($freq_in_config = (int) $config->get('purge-frequency')) {
+	 $fr=($config->get('frequency') > 0) ? $config->get('frequency') : 0;
+        if ($freq_in_config = (int) $fr) {
             // Calculate when we want to run next, config hours into seconds,
             // plus the last run is the timestamp of the next scheduled run
             $next_run = $last_run + ($freq_in_config * 3600);
@@ -218,10 +220,9 @@ class CloserPlugin extends Plugin {
      * @param TicketStatus $new_status
      */
     private function change_ticket_status(Ticket $ticket, TicketStatus $new_status) {
+	 global $ost;
         if (self::DEBUG) {
-            error_log(
-                    "Setting status " . $new_status->getState() .
-                    " for ticket {$ticket->getId()}::{$ticket->getSubject()}");
+            $ost->logWarning("CloserPlugin", "Setting status " . $new_status->getState() . " for ticket {$ticket->getId()}::{$ticket->getSubject()}", false);
         }
 
         // Start by setting the last update and closed timestamps to now
@@ -248,19 +249,19 @@ class CloserPlugin extends Plugin {
      * Retrieves an array of ticket_id's from the database
      *
      * @param PluginConfig $config
-     * @param int $group_id
      * @return array of integers that are Ticket::lookup compatible ID's of Open
      *         Tickets
      * @throws Exception so you have something interesting to read in your cron
      *         logs..
      */
-    private function find_ticket_ids(PluginConfig $config, $group_id) {
-        $from_status = (int) $config->get('from-status-' . $group_id);
+    private function find_ticket_ids(PluginConfig &$config) {
+	 global $ost;
+        $from_status = (int) $config->get('from-status');
         if (!$from_status) {
             throw new \Exception("Invalid parameter (int) from_status needs to be > 0");
         }
 
-        $age_days = (int) $config->get('purge-age-' . $group_id);
+        $age_days = (int) $config->get('purge-age');
         if ($age_days < 1) {
             throw new \Exception("Invalid parameter (int) age_days needs to be > 0");
         }
@@ -270,8 +271,8 @@ class CloserPlugin extends Plugin {
             throw new \Exception("Invalid parameter (int) max needs to be > 0");
         }
 
-        $whereFilter = ($config->get('close-only-answered-' . $group_id)) ? ' AND isanswered=1' : '';
-        $whereFilter .= ($config->get('close-only-overdue-' . $group_id)) ? ' AND isoverdue=1' : '';
+        $whereFilter = ($config->get('close-only-answered')) ? ' AND isanswered=1' : '';
+        $whereFilter .= ($config->get('close-only-overdue')) ? ' AND isoverdue=1' : '';
 
         // Ticket query, note MySQL is doing all the date maths:
         // Sidebar: Why haven't we moved to PDO yet?
@@ -291,7 +292,7 @@ ORDER BY ticket_id ASC
 LIMIT %d", TICKET_TABLE, $age_days, $from_status, $whereFilter, $max);
 
         if (self::DEBUG) {
-            error_log("Looking for tickets with query: $sql");
+            $ost->logWarning("CloserPlugin", "Looking for tickets with query: $sql", false);
         }
 
         $r = db_query($sql);
@@ -314,7 +315,7 @@ LIMIT %d", TICKET_TABLE, $age_days, $from_status, $whereFilter, $max);
      */
     function post_reply(Ticket $ticket, TicketStatus $new_status, $admin_reply, Staff $robot = null) {
         // We need to override this for the notifications
-        global $thisstaff;
+        global $ost, $thisstaff;
 
         if ($robot) {
             $assignee = $robot;
@@ -329,7 +330,7 @@ LIMIT %d", TICKET_TABLE, $age_days, $from_status, $whereFilter, $max);
         }
         // This actually bypasses any authentication/validation checks..
         $thisstaff = $assignee;
-
+	
         // Replace any ticket variables in the message:
         $variables = [
             'recipient' => $ticket->getOwner()
@@ -356,8 +357,8 @@ LIMIT %d", TICKET_TABLE, $age_days, $from_status, $whereFilter, $max);
         // Build an array of values to send to the ticket's postReply function
         // 'emailcollab' => FALSE // don't send notification to all collaborators.. maybe.. dunno.
         $vars = [
-            'response' => $custom_reply,
-            'reply-to' => 'user'
+		'reply-to' => 'all',
+            'response' => $custom_reply
         ];
         $errors = [];
 

--- a/config.php
+++ b/config.php
@@ -1,19 +1,18 @@
 <?php
-
+/**
+ * @file config.php :: 
+ * @  requires osTicket 1.17+ & PHP8.0+
+ * @  multi-instance: yes
+ *
+ * @author Grizly <clonemeagain@gmail.com>
+ * @see https://github.com/clonemeagain/plugin-autocloser
+ * @fork by Cartmega <www.cartmega.com>
+ * @see https://github.com/Cartmega/plugin-autocloser 
+ */
 require_once INCLUDE_DIR . 'class.plugin.php';
 require_once INCLUDE_DIR . 'class.message.php';
 
 class CloserPluginConfig extends PluginConfig {
-
-    /**
-     * How many groups of settings we support. Note: Changing this is a matter of
-     * uninstalling, changing, then reinstalling. Sounds stupid, but no, if you
-     * try and change it live, you risk losing all plugin settings. Not kidding.
-     * Tried to make it dynamic, doesn't work.
-     *
-     * @var integer
-     */
-    const NUMBER_OF_SETTINGS = 4;
 
     // Provide compatibility function for versions of osTicket prior to
     // translation support (v1.9.4)
@@ -35,24 +34,29 @@ class CloserPluginConfig extends PluginConfig {
         list ($__, $_N) = self::translate();
 
         // Validate the free-text fields of numerical configurations are in fact numerical..
-        if (!is_numeric($config['purge-num'])) {
-            $errors['err'] = $__('Only a numeric value is valid for Purge Number.');
-            return FALSE;
-        }
-        foreach (range(1, self::NUMBER_OF_SETTINGS) as $i) {
-            if (isset($config['purge-age-' . $i]) &&
-                    !is_numeric($config['purge-age-' . $i])) {
+        if (isset($config['purge-num']) &&
+	        !is_numeric($config['purge-num'])) {
+	            $errors['err'] = $__('Only a numeric value is valid for Purge Number.');
+	            return FALSE;
+	        }
+	
+            if (isset($config['purge-age']) &&
+                    !is_numeric($config['purge-age'])) {
                 $errors['err'] = $__(
-                        'Group ' . $i . ' Max Ticket age only supports numeric values.');
+                        'Max Ticket age only supports numeric values.');
                 return FALSE;
             }
-        }
+            if (!(isset($config['robot-account'])) || ($config[('robot-account')]==0)) {
+            	//echo '<pre>'.print_r('robot-account'.' is not set "'.$config[('robot-account')].'"',2).'</pre>';
+                $errors['err'] = $__('Please choose a robot-account.');
+                return FALSE;            	
+            }
+            if (!(isset($config['admin-reply'])) || ($config[('admin-reply')]==0)) {
+            	//echo '<pre>'.print_r('admin-reply'.' is not set "'.$config[('admin-reply')].'"',2).'</pre>';
+                $errors['err'] = $__('Please choose an admin-reply.');
+                return FALSE;            	
+            }
 
-        if (self::NUMBER_OF_SETTINGS < 1) {
-            $errors['err'] = $__(
-                    "You must have at least 1 setting group, otherwise, you should disable the plugin.");
-            return FALSE;
-        }
         return TRUE;
     }
 
@@ -76,9 +80,9 @@ class CloserPluginConfig extends PluginConfig {
             $statuses[$id] = $name;
         }
         // Build array of Agents
-        $staff[0] = $__('ONLY Send as Ticket\'s Assigned Agent');
+        $staff[-1] = $__('ONLY Send as Ticket\'s Assigned Agent');
         foreach (Staff::objects() as $s) {
-            $staff[$s->getId()] = $s->getName();
+            $staff[$s->getId()] = (string) $s->getName();
         }
 
         $global_settings = [
@@ -90,7 +94,7 @@ class CloserPluginConfig extends PluginConfig {
                     [
                 'label' => $__('Check Frequency'),
                 'choices' => [
-                    '0' => $__('Every Cron'),
+                    '-1' => $__('Every Cron'),
                     '1' => $__('Every Hour'),
                     '2' => $__('Every 2 Hours'),
                     '6' => $__('Every 6 Hours'),
@@ -114,40 +118,24 @@ class CloserPluginConfig extends PluginConfig {
                     ]),
             'purge-num' => new TextboxField(
                     [
-                'label' => $__('Tickets to process per run per group'),
+                'label' => $__('Tickets to process per run'),
                 'hint' => $__(
-                        "How many tickets should we change each time for each group? (small for auto-cron)"),
+                        "How many tickets should we change each time? (small for auto-cron)"),
                 'default' => 20
                     ]),
         ];
 
-        // Configure groups to associate a status change with a canned response notification:
+        // Configure group to associate a status change with a canned response notification:
         // Get all the canned responses to use as selections:
         $responses = Canned::getCannedResponses();
-        $responses['0'] = $__('Send no Reply');
+        $responses['-1'] = $__('Send no Reply');
+        ksort($responses);
 
-        // Build an array of group configurations:
-        $config_groups = [];
-        foreach (range(1, self::NUMBER_OF_SETTINGS) as $i) {
-            $gn = $this->get('group-name-' . $i);
-            $gn = $gn ? ': ' . $gn : '';
-            $config_groups[] = [
-                'group' . $i => new SectionBreakField(
-                        [
-                    'label' => $__('Group ' . $i . $gn)
-                        ]),
-                'group-enabled-' . $i => new BooleanField(
-                        [
-                    'label' => __('Enable Group'),
-                    'hint' => __('Groups can be configured without being enabled. '),
-                    'default' => ($i == 1) ? TRUE : FALSE // Enable first group by default.
-                        ]),
-                'group-name-' . $i => new TextboxField(
-                        [
-                    'label' => 'Groupname',
-                    'hint' => $__('Name this group')
-                        ]),
-                'purge-age-' . $i => new TextboxField(
+        // Build a group configuration:
+        $config_group = [];
+
+            $config_group[] = [
+                'purge-age' => new TextboxField(
                         [
                     'default' => '999',
                     'label' => $__('Max Ticket age in days'),
@@ -156,19 +144,19 @@ class CloserPluginConfig extends PluginConfig {
                     'size' => 5,
                     'length' => 4
                         ]),
-                'close-only-answered-' . $i => new BooleanField(
+                'close-only-answered' => new BooleanField(
                         [
                     'default' => TRUE,
                     'label' => $__('Only change tickets with an Agent Response'),
                     'hint' => ''
                         ]),
-                'close-only-overdue-' . $i => new BooleanField(
+                'close-only-overdue' => new BooleanField(
                         [
                     'default' => FALSE,
                     'label' => $__('Only change tickets past expiry date'),
                     'hint' => $__('Default ignores expiry')
                         ]),
-                'from-status-' . $i => new ChoiceField(
+                'from-status' => new ChoiceField(
                         [
                     'label' => $__('From Status'),
                     'choices' => $statuses,
@@ -176,7 +164,7 @@ class CloserPluginConfig extends PluginConfig {
                     'hint' => $__(
                             'When we change the ticket, what are we changing the status from? Default is "Open"')
                         ]),
-                'to-status-' . $i => new ChoiceField(
+                'to-status' => new ChoiceField(
                         [
                     'label' => $__('To Status'),
                     'choices' => $statuses,
@@ -184,7 +172,7 @@ class CloserPluginConfig extends PluginConfig {
                     'hint' => $__(
                             'When we change the ticket, what are we changing the status to? Default is "Closed"')
                         ]),
-                'admin-note-' . $i => new TextareaField(
+                'admin-note' => new TextareaField(
                         [
                     'label' => $__('Auto-Note'),
                     'hint' => $__('Create\'s an admin note just before closing.'),
@@ -195,7 +183,7 @@ class CloserPluginConfig extends PluginConfig {
                         'length' => 256
                     ]
                         ]),
-                'robot-account-' . $i => new ChoiceField(
+                'robot-account' => new ChoiceField(
                         [
                     'label' => $__('Robot Account'),
                     'choices' => $staff,
@@ -203,7 +191,7 @@ class CloserPluginConfig extends PluginConfig {
                     'hint' => $__(
                             'Select account for sending replies, account can be locked, still works.')
                         ]),
-                'admin-reply-' . $i => new ChoiceField(
+                'admin-reply' => new ChoiceField(
                         [
                     'label' => $__('Auto-Reply Canned Response'),
                     'hint' => $__(
@@ -211,21 +199,18 @@ class CloserPluginConfig extends PluginConfig {
                     'choices' => $responses
                         ])
             ];
-        }
 
         if (version_compare(PHP_VERSION, '5.6.0') >= 0) {
             // Merge all the group configurations into the global settings array and return as the config
-            return array_merge($global_settings, ...$config_groups);
+            return array_merge($global_settings, ...$config_group);
         }
 
 
         // Support pre 5.6... oi vey
         $settings = $global_settings;
-        foreach ($config_groups as $group) {
-            foreach ($group as $setting) {
+            foreach ($config_group as $setting) {
                 $settings[] = $setting;
             }
-        }
         return $settings;
     }
 

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php return array(
  'id' => 'clonemeagain:autocloser', # notrans
- 'version' => '3.0',
+ 'version' => '3.1',
  'name' => 'Ticket Closer',
  'author' => 'clonemeagain@gmail.com',
  'description' => 'Changes ticket statuses based on age.',
@@ -8,3 +8,37 @@
  'plugin' => 'class.CloserPlugin.php:CloserPlugin',
  'ost_version' =>    '1.17', # Require osTicket v1.17	
 );
+
+/*
+CHANGELOG
+---------
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.0] - 2023-01-15
+### Added
+- Consolidate messages and log to osTicket syslog once per run, 
+  instead of multiple times per run.
+
+### Fixed
+- Removed print commands to avoid sending output back to CRON caller.
+
+## [3.0.0] - 2023-01-11
+### Added
+- Compatibility with osTicket 1.17.
+- Multi-instance capability.
+- Send log entries to osTicket syslog instead of to web server's error log (error_log).
+
+### Removed
+- Multiple config options removed from previous version (use instances instead)
+
+## [2.1.0] - 2019-10-13
+### Fixed
+- Forked from original github version.
+
+*/

--- a/plugin.php
+++ b/plugin.php
@@ -1,9 +1,10 @@
 <?php return array(
  'id' => 'clonemeagain:autocloser', # notrans
- 'version' => '2.0',
+ 'version' => '3.0',
  'name' => 'Ticket Closer',
  'author' => 'clonemeagain@gmail.com',
  'description' => 'Changes ticket statuses based on age.',
  'url' => 'https://github.com/clonemeagain/osticket-plugin-closer',
- 'plugin' => 'class.CloserPlugin.php:CloserPlugin'
+ 'plugin' => 'class.CloserPlugin.php:CloserPlugin',
+ 'ost_version' =>    '1.17', # Require osTicket v1.17	
 );

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php return array(
  'id' => 'clonemeagain:autocloser', # notrans
- 'version' => '3.1',
+ 'version' => '3.1.1',
  'name' => 'Ticket Closer',
  'author' => 'clonemeagain@gmail.com',
  'description' => 'Changes ticket statuses based on age.',
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.1.1] - 2023-01-15
+### Added
+- Changed an $ost->logWarning into $this->LOG[] which I missed earlier.
 
 ## [3.1.0] - 2023-01-15
 ### Added


### PR DESCRIPTION
We have modified autocloser to comply with osTicket 1.17 multi-instance capabilities. This allows the plugin to be configured with as many configurations as needed. Various issues with the original version have also been fixed.