### PR TITLE
Add support for help topic filtering.

### DIFF
--- a/config.php
+++ b/config.php
@@ -164,6 +164,25 @@ class CloserPluginConfig extends PluginConfig {
                     'hint' => $__(
                             'When we change the ticket, what are we changing the status from? Default is "Open"')
                         ]),
+                'help-topics' => new ChoiceField(
+                        [
+                    'id' => 'help-topics',
+                    'label' => __('Help Topics'),
+                    'choices' => (function() {
+                        if (class_exists('Topic') && method_exists('Topic', 'getHelpTopics')) {
+                            try {
+                                $topics = Topic::getHelpTopics();
+                                return $topics ?: [];
+                            } catch (Throwable $e) {
+                                return [];
+                            }
+                        }
+                        return [];
+                    })(),
+                    'configuration' => ['multiselect' => true],
+                    'default' => [],
+                    'hint' => __('Only tickets with one of these help topics will be processed. Leave empty to include all topics.')
+                        ]),
                 'to-status' => new ChoiceField(
                         [
                     'label' => $__('To Status'),


### PR DESCRIPTION
This pull request introduces a feature to filter tickets by selected help topics in the AutoCloser plugin for osTicket. With this enhancement, administrators can configure the plugin to only process and close tickets that belong to specific help topics. This allows for more granular control over which tickets are affected by the automatic closing process.

![helptopic_filter](https://github.com/user-attachments/assets/8b687e22-9c96-4f1b-af64-a4a001b4afdc)
(Screenshot taken using osTicket Awesome design)

### Key Changes

- Added logic to filter tickets by help topic IDs as configured in the plugin settings.
- Only tickets matching the selected help topics will be considered for automatic closure.
- If no help topics are selected, the plugin will process all tickets as before.

### Motivation

This enhancement allows administrators to apply auto-closing rules only to specific categories of tickets, or to exclude certain topics from automatic closure.  
**Additionally, since the plugin supports multiple instances with separate configurations, it is now possible to define different rules and settings for each help topic or group of topics.**  
This provides more granular control and flexibility in ticket management.